### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 TwitterClient	KEYWORD1
-TwitterWebAPI   KEYWORD1
+TwitterWebAPI	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-tweet	        KEYWORD2
+tweet	KEYWORD2
 searchTwitter	KEYWORD2
-searchUser      KEYWORD2
+searchUser	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-consumer_key LITERAL1
-consumer_sec LITERAL1
-accesstoken LITERAL1
-accesstoken_sec LITERAL1
+consumer_key	LITERAL1
+consumer_sec	LITERAL1
+accesstoken	LITERAL1
+accesstoken_sec	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords